### PR TITLE
fix: handle bullet points in reference blocks

### DIFF
--- a/src/utils/functions/index.ts
+++ b/src/utils/functions/index.ts
@@ -125,10 +125,23 @@ const parseMarkdown = (md: string, fromHTML?: boolean) => {
         )
 }
 
+const getBulletedListItem = (bulletListItem: any) => {
+  if (bulletListItem.type !== "bulleted_list_item") return ""
+  const content = bulletListItem.bulleted_list_item.rich_text[0].text.content
+  return content
+}
+
 const getQuoteContent = (quoteBlock: any) => {
   if (quoteBlock.type !== "quote") return ""
-  const child = quoteBlock.quote.children?.[0]
-  const content: string = child.paragraph.rich_text[0].text.content
+  const children = quoteBlock.quote.children
+  const content = children.reduce((acc: string, child: any) => {
+    if (child.type == "bulleted_list_item") {
+      const childContent = getBulletedListItem(child)
+      return acc + "- " + childContent + "\n"
+    }
+    const childContent: string = child.paragraph.rich_text[0].text.content
+    return acc + childContent + " "
+  }, "")
   return content
 }
 


### PR DESCRIPTION
If there's a reference block with bullet points only, this extension will fail to export:

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/8b85363d-f7f0-47e6-bdd0-a340f40eaf91" />

```
Error message: Cannot read properties of undefined (reading 'rich_text')

Error code: 400
```

My prompt:
```
> - SEC Rule 606 requires broker-dealers to disclose routing practices for non-directed orders.  
> - Robinhood’s PFOF model has drawn scrutiny over potential conflicts of interest and order execution quality.
output the text above with nothing else
```